### PR TITLE
#254 serial number remove from form

### DIFF
--- a/modules/forms/chapters_form.py
+++ b/modules/forms/chapters_form.py
@@ -6,4 +6,4 @@ from modules.models import ChapterModel
 class ChaptersForm(forms.ModelForm):
     class Meta:
         model = ChapterModel
-        fields = ['title', 'description', 'serial_number']
+        fields = ['title', 'description']

--- a/templates/chapters/chapter_detail.html
+++ b/templates/chapters/chapter_detail.html
@@ -41,7 +41,7 @@
                     <tbody>
                     {% for step in steps|dictsort:"serial_number" %}
                         <tr>
-                            <td>{{ chapter.serial_number }}</td>
+                            <td>{{ step.serial_number }}</td>
                             <td><a href="{% url 'step:stepmodel_detail' step.id %}">{{ step.title }}</a></td>
                             <td class="text-end">
                                 <div class="btn-group">


### PR DESCRIPTION
Resolve #254 
Убрал поле serial_number из формы главы.
В шаблоне главы исправил отображение порядкового номера шагов.